### PR TITLE
add some missing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ The `app.py` reads the `graph_data.gml` file generated at step 1 and creates a R
 **Warning** 
 The code is a bare minimum product, doesn't cover all services and options and is quite chaotic! it demonstrates the idea and how we could start implementing it.
 
+Possible issues and solutions
+============
+
+- If you run `python app.py` and see an error saying `No such file or directory: 'neato'`, you will have to install `graphviz` on your machine (the package version from pip doesn't seem to work) - check how to install [here](https://graphviz.org/download/)
+
 Contributing
 ============
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ networkx
 dash
 plotly
 pymysql
+pydot
+colour


### PR DESCRIPTION
# About this change - What it does

`pydot` and `colour` were at least missing from the requirements.txt so added those.

Additionally added a note on having to install `graphviz` separately if you get the specified error when running `python app.py`. I did try installing it through pip as well but that didn't seem to work, however I didn't look too deeply into it and if it could be solved that way as well.


