### PR TITLE
Add cryptography package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ plotly
 pymysql
 pydot
 colour
+cryptography==38.0.1


### PR DESCRIPTION
MySQL handling can require
the cryptography package.

This commit adds and pin the
version of cryptography to
the requirements.

Fixes #31

Signed-off-by: laysa.uchoa <laysa.uchoa@aiven.io>

