### PR TITLE
Patching Vulnerable OpenSSL included in cryptography wheels 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ plotly
 pymysql
 pydot
 colour
-cryptography==38.0.1
+cryptography==38.0.3
 sqllineage


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
>= 37.0.0, < 38.0.3

<!-- Provide a small sentence that summarizes the change. -->
pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 37.0.0-38.0.3 are vulnerable to a number of security issues. More details about the vulnerabilities themselves can be found in https://www.openssl.org/news/secadv/20221101.txt.

If you are building cryptography source ("sdist") then you are responsible for upgrading your copy of OpenSSL. Only users installing from wheels built by the cryptography project (i.e., those distributed on PyPI) need to update their cryptography versions.

<!-- Provide the issue number below if it exists. -->
Resolves: #38.0.3



