### PR TITLE
Fix typo in dependencies file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ simplejson
 aiven.client
 configparser
 pyvis==0.3.1
-networkx=2.8.8
+networkx==2.8.8
 dash
 plotly
 pymysql


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Fixes typo in dependency file
'networkx=2.8.8' -> 'networkx==2.8.8'
<!-- Provide the issue number below if it exists. -->
Resolves: #52 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
I am assuming that '=' was intended as equal '=='

