### PR TITLE
Epic 1/add ci

### DIFF
--- a/.github/workflows/parser_ci.yml
+++ b/.github/workflows/parser_ci.yml
@@ -1,0 +1,27 @@
+name: parser CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  test_parser:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: python_setup
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: install_dependencies
+      run: |
+        echo "python -m pip install --upgrade pip"
+        echo "pip install -r requirements.txt"

--- a/.github/workflows/parser_ci.yml
+++ b/.github/workflows/parser_ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+  
 env:
   CONFIG_FILE_PATH: ./conf/conf.env
   BASE_URL: https://api.aiven.io

--- a/.github/workflows/parser_ci.yml
+++ b/.github/workflows/parser_ci.yml
@@ -8,20 +8,62 @@ on:
     branches:
     - main
 
+env:
+  CONFIG_FILE_PATH: ./conf/conf.env
+  BASE_URL: https://api.aiven.io
+
 jobs:
   test_parser:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-
     - uses: actions/checkout@v3
 
-    - name: python_setup
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
 
-    - name: install_dependencies
+    - name: Install dependencies
       run: |
-        echo "python -m pip install --upgrade pip"
-        echo "pip install -r requirements.txt"
+        python -m pip install --upgrade pip
+        [[ -f requirements.txt ]] && pip install -r requirements.txt
+
+    - name: Set temporary config file
+      run: |
+        cat <<EOF > $CONFIG_FILE_PATH
+        #!/bin/bash
+        PROJECT=${{ vars.PROJECT }}
+        TOKEN=${{ secrets.TOKEN }}
+        BASE_URL=$BASE_URL
+        EOF
+
+    - name: Run main.py script
+      run: |
+        python main.py
+
+    - name: Check that the script created the files
+      run: |
+        file_name="graph_data.dot"
+        [[ -f ./$file_name ]] && echo "$file_name created - OK" || exit 1
+        file_name="graph_data.gml"
+        [[ -f ./$file_name ]] && echo "$file_name created - OK" || exit 1
+        file_name="nx.html"
+        [[ -f ./$file_name ]] && echo "$file_name created - OK" || exit 1
+
+    - name: Run app.py server
+      run: |
+        python app.py &
+    - name: Check that the server is reachable
+      run: |
+        head=$(curl --head http://127.0.0.1:8050/ | head -n 1)
+        [[ $head = *"200 OK"* ]] && echo "$head" || exit 1
+
+  do_something_else:
+    runs-on: ubuntu-latest
+    needs: test_parser
+    steps:
+    - run: echo "Doing something else"


### PR DESCRIPTION
# About this change - What it does
Add draft CI for metadata-parser

1. setup python
2. install dependencies
3. configure variables and secrets
4. test script and server

Resolves: #1

# Why this way
This way of setting up the CI pipeline follows best practices for Python projects.
As the workflow it is divided in clear steps, it is easier for other developers to understand how it works and make changes if necessary.
If the pipeline grows in the future it may be worth separating the jobs in different workflow files, for now it would add unnecessary complexity.
Using github variables and secrets, we can ensure that the pipeline is secure and that sensitive information is not exposed.
