### PR TITLE
Add initial configs for coding standards.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp
 .vscode
 *.log
 .ropeproject
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: check-ast
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.6
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, .]
+        types: [python]
+      - id: ruff-format
+        args: [.]
+        types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "space"
+
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  "B",
+  # flake8-simplify
+  "SIM",
+  # isort
+  "I",
+]


### PR DESCRIPTION
Added pre commit config using ruff as linter and formatter.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Adds some basic configuration for git hooks using pre-commit framework.
Adds some basic configuration for ruff tool for linting and formatting python code.

<!-- Provide the issue number below if it exists. -->
Resolves: #25

# Why this way
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
This project is a great testing ground for ruff. As opposed to more stable, battle-tested tools which one may choose for a production project (i.e.: black, flake, pylint, ..).
Ruff formatter is supposedly compatible with black formatter.
Ruff linter can use rules from many commonly used analyzers, parsers, linters.. (i.e.:pyflakes, isort, ..)

